### PR TITLE
Refix Wrong variable <OTRS_CUSTOMER_REALNAME> in AutoResponses #4640

### DIFF
--- a/Kernel/System/TemplateGenerator.pm
+++ b/Kernel/System/TemplateGenerator.pm
@@ -1553,7 +1553,7 @@ sub _Replace {
 
                 # generate real name based on sender line
                 if ( !$From ) {
-                    $From = $Data{From} || '';
+                    $From = $Data{To} || '';
 
                     # remove email addresses
                     $From =~ s/&lt;.*&gt;|<.*>|\(.*\)|\"|&quot;|;|,//g;


### PR DESCRIPTION
This is a one-line partial revert of 82d55d6 which introcuded a condition where
the From field in an Auto Response would be badly generated. This is documented
in Bug #4640 comments 15 and 16. The field that should be used instead is the To
field and not the From since the generated email already has those headers set